### PR TITLE
Drop support for the armv7 architecture

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@
 ![Project Stage][project-stage-shield]
 [![License][license-shield]](LICENSE.md)
 
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -108,8 +105,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-nginx-proxy-manager.svg
 [commits]: https://github.com/hassio-addons/addon-nginx-proxy-manager/commits/main
 [contributors]: https://github.com/hassio-addons/addon-nginx-proxy-manager/graphs/contributors
@@ -124,7 +119,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-nginx-proxy-manager/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-nginx-proxy-manager/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-nginx-proxy-manager.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/proxy-manager/build.yaml
+++ b/proxy-manager/build.yaml
@@ -2,7 +2,6 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.0
   amd64: ghcr.io/hassio-addons/base:18.2.0
-  armv7: ghcr.io/hassio-addons/base:18.2.0
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/proxy-manager/config.yaml
+++ b/proxy-manager/config.yaml
@@ -11,7 +11,6 @@ init: false
 arch:
   - aarch64
   - amd64
-  - armv7
 hassio_api: true
 ports:
   80/tcp: 80


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Home Assistant only supports `aarch64` and `amd64` these days, and our add-on base image dropped everything else in [v19.0.0](https://github.com/hassio-addons/addon-base/releases/tag/v19.0.0).

For end users, the only actual change here is that **`armv7` is no longer supported**. That was the last 32 bit architecture this add-on still shipped for. `armhf` and `i386` were already unsupported: they were not in the `arch` list, and the README badges for them had been red "no" badges for ages. Those leftovers are cleaned up here too, but they do not change what anyone can install.

Concretely:

* `proxy-manager/config.yaml`: removed `armv7` from the `arch` list, leaving `aarch64` and `amd64`.
* `proxy-manager/build.yaml`: removed the `armv7` entry from `build_from`.
* `README.md`: removed the stale `armhf`, `armv7` and `i386` badges, along with their now unused link definitions.
* `.github/renovate.json`: narrowed the `build_from` custom manager regex from `(aarch64|amd64|armhf|armv7|i386)` to `(aarch64|amd64)`, so Renovate stops looking for architectures we do not ship.

This unblocks #696, which bumps the add-on base image to v21 (Alpine 3.24). That bump cannot go in while `armv7` is still listed, because `ghcr.io/hassio-addons/base:21.0.2` is published for `arm64` and `amd64` only.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Unblocks #696

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
