### PR TITLE
Remove deprecated codenotary fields and resolve shellcheck findings

### DIFF
--- a/proxy-manager/build.yaml
+++ b/proxy-manager/build.yaml
@@ -2,6 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.0
   amd64: ghcr.io/hassio-addons/base:18.2.0
-codenotary:
-  base_image: codenotary@frenck.dev
-  signer: codenotary@frenck.dev

--- a/proxy-manager/config.yaml
+++ b/proxy-manager/config.yaml
@@ -4,7 +4,6 @@ version: dev
 slug: nginxproxymanager
 description: Manage Nginx proxy hosts with a simple, powerful interface
 url: https://github.com/hassio-addons/addon-nginx-proxy-manager
-codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:81]
 startup: services
 init: false

--- a/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
+++ b/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community Add-on: Nginx Proxy Manager
 # Take down the S6 supervision tree when NGINX fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="NGINX"
@@ -15,7 +16,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo $((128 + exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/npm/finish
+++ b/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/npm/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community Add-on: Nginx Proxy Manager
 # Take down the S6 supervision tree when Nginx Proxy Manager fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="Nginx Proxy Manager"
@@ -15,7 +16,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo $((128 + exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

CI on `main` is currently red on **Lint App** and **Shellcheck**. Neither failure comes from a code change: `main` last ran CI in October 2025 and was green then. Both linters float rather than pin their versions, so this is simply tooling drift catching up with us. This PR gets `main` back to green.

**Lint App: remove the deprecated `codenotary` fields**

The linter now errors with `'codenotary' is deprecated and no longer used. Please remove this field.`, once for each file that still carries it. Codenotary was shut down, and the base add-on removed these fields a while back. Removed from:

* `proxy-manager/config.yaml`: the `codenotary: codenotary@frenck.dev` key.
* `proxy-manager/build.yaml`: the whole `codenotary:` block with its `base_image` and `signer` keys.

**Shellcheck: fix four findings in the `finish` scripts**

Both `nginx/finish` and `npm/finish` tripped the same two checks. These files were last touched in #499 and a newer shellcheck simply got stricter:

* `SC2155` (declare and assign separately to avoid masking return values): split `readonly exit_code_container=$(<...)` into a plain assignment followed by `readonly exit_code_container`.
* `SC2004` (`$`/`${}` is unnecessary on arithmetic variables): `$((128 + $exit_code_signal))` becomes `$((128 + exit_code_signal))`.

Both are stylistic and behaviour preserving. I verified the arithmetic change produces identical output for every signal value that can actually reach it. The only case where the two forms differ at all is when the variable is unset, where the old form is a bash syntax error and the new form yields `128`. That cannot happen here, since s6 always passes the signal as `$2`, but the new form is the more robust of the two regardless.

Verified by running the same shellcheck invocation CI uses (`-s bash --format=gcc`) over all six shell scripts in the repo: all clean, exit code 0.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Gets `main` back to green, so #696 can land on a passing baseline.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

---

### A note on the remaining red `Build` check

Both target jobs are now green: **Lint App** passes and **Shellcheck** passes. The `Build aarch64` / `Build amd64` jobs now go red, but they are not a regression from this PR.

In the reusable workflow, `build` has `needs: [information, lint-app, lint-hadolint, lint-json, lint-prettier, lint-shellcheck]`. While the two linters were failing, `build` was skipped and never actually ran. Fixing the linters simply let it run for the first time, which uncovered a second, older problem sitting underneath.

That problem is that `main` cannot build at all. The pins in the Dockerfile point at Alpine 3.22 package revisions that have since been superseded and dropped from the mirrors, so `apk add` fails with `unable to select packages`. I reproduced this locally by building `main`'s Dockerfile untouched: it fails on `build-base=0.5-r3`, `git=2.49.1-r0`, `nginx=1.28.0-r3` and friends. This PR changes none of those pins.

#696 is the fix: it moves to Alpine 3.24 and refreshes every pin, and I have confirmed that tree builds cleanly. So `main` goes fully green once both this PR and #696 have landed, in either order.
