### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,8 +31,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -40,8 +47,20 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": [
+        "alpine_3_24/certbot",
+        "alpine_3_24/npm",
+        "alpine_3_24/yarn"
+      ],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",
@@ -65,19 +84,19 @@
     },
     {
       "groupName": "NGINX",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchDepNames": ["/^alpine.*/nginx.*/"]
     },
     {
       "groupName": "OpenSSL",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchDepNames": ["/^alpine.*/openssl.*/"]
     },
     {
       "groupName": "Python",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchDepNames": ["/^alpine.*/python.*/"]
     },


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the org. Every `alpine_X_YY/*` lookup returns `no-result`, so Alpine pins stop being updated entirely and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and each run resolves every pin through it.

This applies the same fix already landed on app-ssh (hassio-addons/app-ssh#1119) to this repository, replacing Repology with a custom datasource that reads the Alpine CDN directory listing directly.

In `.github/renovate.json`:

1. Added a `customDatasources.alpine` entry pointing at `https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/` with `format: html`. The `v3.24` branch is taken from this repository's own `depNameTemplate` (`alpine_3_24/{{package}}`).
2. The Alpine custom manager switches to `"datasourceTemplate": "custom.alpine"` and gains `"extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"`, which pulls the version out of each `href` in the directory listing. The `\d` anchor is what stops a package matching a longer sibling name.
3. All four `"matchDatasources": ["repology"]` package rules switch to `["custom.alpine"]`: the generic automerge rule plus the NGINX, OpenSSL and Python group rules.
4. Added one rule giving the community packages their own `registryUrls`. Custom datasources use `registryStrategy: "first"`, so multiple registry URLs are not hunted and community packages cannot resolve without this.

The community list was derived mechanically from this repository's Dockerfile against both v3.24 APKINDEX files rather than copied from app-ssh. For this repository it is three packages: `certbot`, `npm` and `yarn`. The other fifteen pins live in `main`.

## What was verified

Verified locally with the Renovate container, since a green CI run proves nothing here: this change does not touch the Dockerfile, so buildx serves the `apk` layer from cache and no `apk add` ever runs.

- `renovate-config-validator` passes: "Config validated successfully against 1 file(s)".
- Dry run (`RENOVATE_PLATFORM=local`, `RENOVATE_DRY_RUN=lookup`, `LOG_LEVEL=debug`) completes with exit code 0.
- **Zero lookup failures.** `Found no results` appears 0 times, and there are no `no-result` or lookup-failed entries. The only warning in the whole run is `GitHub token is required for some dependencies`, which relates to the unrelated `github-releases` datasource and is expected without a token.
- **Dep count matches.** Renovate extracts exactly 18 `alpine_3_24/*` dependencies, and the Dockerfile has exactly 18 pinned packages.
- **The community rule targets exactly the right packages.** The community registry URL appears exactly 3 times in the resolved output, matching `certbot`, `npm` and `yarn` and nothing else.
- **Every pin resolved a `currentVersion`**, which only happens when the datasource returned a usable version list and the pin was matched inside it.
- **Updates found: none.** Renovate reports `0 flattened updates found`. Cross-checked independently against the two APKINDEX files: all 18 pins already sit at the latest v3.24 version, so Renovate and the index agree. No pin in this repository went stale while Repology was down, so no follow-up bumps are expected once this merges, and nothing here is blocking another PR.

Every pinned package resolves in either `main` or `community`; none are missing from both.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Applies the fix from hassio-addons/app-ssh#1119 to this repository.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated tracking of Alpine Linux packages and updates.
  * Updated package monitoring for NGINX, OpenSSL, Python, and community packages.
  * Enabled eligible Alpine package updates to be merged automatically, helping keep supported components current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->