### PR TITLE
Fix broken links, stale badges and product name capitalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You have several options to get them answered:
 - The Home Assistant [Community Forum][forum].
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
 
-You could also [open an issue here][issue] GitHub.
+You could also [open an issue here][issue] on GitHub.
 
 ## Contributing
 
@@ -55,7 +55,7 @@ This is an active open-source project. We are always open to people who want to
 use the code or contribute to it.
 
 We have set up a separate document containing our
-[contribution guidelines](CONTRIBUTING.md).
+[contribution guidelines](.github/CONTRIBUTING.md).
 
 Thank you for being involved! :heart_eyes:
 
@@ -114,7 +114,7 @@ SOFTWARE.
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
 [patreon-shield]: https://frenck.dev/wp-content/uploads/2019/12/patreon.png
 [patreon]: https://www.patreon.com/frenck
-[project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
+[project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
 [reddit]: https://reddit.com/r/homeassistant
 [releases-shield]: https://img.shields.io/github/release/hassio-addons/app-nginx-proxy-manager.svg
 [releases]: https://github.com/hassio-addons/app-nginx-proxy-manager/releases

--- a/proxy-manager/.README.j2
+++ b/proxy-manager/.README.j2
@@ -67,10 +67,10 @@ If you are more interested in stable releases of our apps:
 {% endif %}
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
 [patreon-shield]: https://frenck.dev/wp-content/uploads/2019/12/patreon.png
 [patreon]: https://www.patreon.com/frenck
-[project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
+[project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
 [release-shield]: https://img.shields.io/badge/version-{{ version }}-blue.svg
 [release]: {{ repo }}/tree/{{ version }}
 [screenshot]: https://github.com/hassio-addons/app-nginx-proxy-manager/raw/main/images/screenshot.gif

--- a/proxy-manager/DOCS.md
+++ b/proxy-manager/DOCS.md
@@ -63,7 +63,7 @@ You have several options to get them answered:
 - The Home Assistant [Community Forum][forum].
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
 
-You could also [open an issue here][issue] GitHub.
+You could also [open an issue here][issue] on GitHub.
 
 ## Authors & contributors
 
@@ -101,7 +101,7 @@ SOFTWARE.
 [contributors]: https://github.com/hassio-addons/app-nginx-proxy-manager/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
-[forum]: https://community.home-assistant.io/t/home-assistant-community-app-nginx-proxy-manager/111830?u=frenck
+[forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-nginx-proxy-manager/111830?u=frenck
 [frenck]: https://github.com/frenck
 [issue]: https://github.com/hassio-addons/app-nginx-proxy-manager/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-npm/run
+++ b/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-npm/run
@@ -31,7 +31,7 @@ ln -s /config /opt/nginx-proxy-manager/config
 
 ln -sf /config/letsencrypt /etc/letsencrypt
 
-# NGinx needs this file to be able to start.
+# Nginx needs this file to be able to start.
 # It will not continously log into it.
 mkdir -p /var/lib/nginx/logs
 touch /var/lib/nginx/logs/error.log

--- a/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -5,7 +5,7 @@
 # Runs the nginx proxy manager interface
 # ==============================================================================
 
-bashio::log.info "Starting NGinx..."
+bashio::log.info "Starting Nginx..."
 
 # Create required folders
 mkdir -p \

--- a/proxy-manager/translations/en.yaml
+++ b/proxy-manager/translations/en.yaml
@@ -1,5 +1,5 @@
 ---
 network:
   80/tcp: HTTP Entrance port
-  81/tcp: NGinx Proxy Manager Admin web interface
+  81/tcp: Nginx Proxy Manager Admin web interface
   443/tcp: HTTPS/SSL Entrance port


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Documentation and metadata fixes found while reviewing the repository. No functional change.

**Broken link.** `README.md` linked to `CONTRIBUTING.md` relative to the repository root, but that file lives in `.github/`, so the link 404s. Now points at `.github/CONTRIBUTING.md`, matching app-node-red.

**Stale maintenance badge.** `proxy-manager/.README.j2` still pointed at `maintenance/yes/2025.svg`. It was missed when the year was bumped in #741, which only updated `README.md`. This is the template the add-on store README is generated from, so it is the one users actually see.

**Mangled forum URL.** The add-on to app rename in #741 rewrote the Home Assistant forum thread slug in `DOCS.md` to `home-assistant-community-app-nginx-proxy-manager`. That slug belongs to an existing thread and should not have changed. It was corrected in `README.md` and `.README.j2` at the time but missed here. The old link still resolves because Discourse redirects on the topic ID, so this was cosmetic rather than broken.

**Project stage.** Both READMEs badged the project as experimental. This add-on dates from 2019 and is widely deployed, so it now reads production ready, consistent with app-node-red.

**Product name.** `NGinx` becomes `Nginx` in the three places it appeared: the port description shown in the Home Assistant UI, a comment in `init-npm/run`, and the startup log line in `nginx/run`.

**Grammar.** "You could also open an issue here GitHub" gains the missing "on", in both `README.md` and `DOCS.md`.

## Verification

- Every relative Markdown link in `README.md` and `DOCS.md` now resolves to a file that exists.
- Both new badge URLs return HTTP 200.
- Prettier, YAMLLint and Shellcheck all clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Corrects two regressions introduced by #741.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support, contribution, and forum links for clarity and accuracy.
  * Marked the project as production ready in project status badges.
  * Updated the maintenance badge year to 2026.

* **Style**
  * Corrected “Nginx” capitalization in startup messages and network-related translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->