### PR TITLE
Harden the service initialisation scripts

### DIFF
--- a/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -1,11 +1,15 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community App: NGINX Proxy Manager
-# Configures NGINX for use with the NGINX Proxy Manager
+# Home Assistant Community App: Nginx Proxy Manager
+# Configures Nginx for use with the Nginx Proxy Manager
 # ==============================================================================
 declare dns_host
 
 dns_host=$(bashio::dns.host)
+bashio::var.has_value "${dns_host}" \
+    || bashio::exit.nok "Could not determine the Home Assistant DNS host"
+
 sed -i "s/%%dns_host%%/${dns_host}/g" \
-    /etc/nginx/conf.d/include/resolvers.conf
+    /etc/nginx/conf.d/include/resolvers.conf \
+    || bashio::exit.nok "Could not configure the Nginx resolver"

--- a/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-npm/run
+++ b/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-npm/run
@@ -20,19 +20,26 @@ mkdir -p \
     /tmp/letsencrypt-lib \
     /tmp/letsencrypt-log \
     /tmp/nginx/body \
-    /tmp/nginx/cache/private\
+    /tmp/nginx/cache/private \
     /tmp/nginx/cache/public \
     /tmp/nginx/proxy \
-    /var/lib/nginx/
+    /var/lib/nginx \
+    || bashio::exit.nok "Could not create the required directories"
 
-ln -s /tmp/nginx /var/tmp/nginx
-ln -s /tmp/nginx /var/lib/nginx/tmp
-ln -s /config /opt/nginx-proxy-manager/config
-
-ln -sf /config/letsencrypt /etc/letsencrypt
+ln -sfn /tmp/nginx /var/tmp/nginx \
+    || bashio::exit.nok "Could not link the Nginx temporary directory"
+ln -sfn /tmp/nginx /var/lib/nginx/tmp \
+    || bashio::exit.nok "Could not link the Nginx working directory"
+ln -sfn /config /opt/nginx-proxy-manager/config \
+    || bashio::exit.nok "Could not link the app configuration directory"
+ln -sfn /config/letsencrypt /etc/letsencrypt \
+    || bashio::exit.nok "Could not link the Let's Encrypt directory"
 
 # Nginx needs this file to be able to start.
 # It will not continously log into it.
-mkdir -p /var/lib/nginx/logs
-touch /var/lib/nginx/logs/error.log
-chmod 777 /var/lib/nginx/logs/error.log
+mkdir -p /var/lib/nginx/logs \
+    || bashio::exit.nok "Could not create the Nginx log directory"
+touch /var/lib/nginx/logs/error.log \
+    || bashio::exit.nok "Could not create the Nginx error log"
+chmod 644 /var/lib/nginx/logs/error.log \
+    || bashio::exit.nok "Could not set permissions on the Nginx error log"

--- a/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-npm/run
+++ b/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-npm/run
@@ -26,13 +26,13 @@ mkdir -p \
     /var/lib/nginx \
     || bashio::exit.nok "Could not create the required directories"
 
-ln -sfn /tmp/nginx /var/tmp/nginx \
+ln -sfT /tmp/nginx /var/tmp/nginx \
     || bashio::exit.nok "Could not link the Nginx temporary directory"
-ln -sfn /tmp/nginx /var/lib/nginx/tmp \
+ln -sfT /tmp/nginx /var/lib/nginx/tmp \
     || bashio::exit.nok "Could not link the Nginx working directory"
-ln -sfn /config /opt/nginx-proxy-manager/config \
+ln -sfT /config /opt/nginx-proxy-manager/config \
     || bashio::exit.nok "Could not link the app configuration directory"
-ln -sfn /config/letsencrypt /etc/letsencrypt \
+ln -sfT /config/letsencrypt /etc/letsencrypt \
     || bashio::exit.nok "Could not link the Let's Encrypt directory"
 
 # Nginx needs this file to be able to start.


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Makes the two oneshot init scripts fail loudly instead of silently, and makes them safe to run more than once.

**Errors were silently swallowed.** Neither script checked any command. An s6 oneshot reports the exit status of its last command, so a failed `mkdir` or `ln` left the service reporting success and the add-on continuing into a half-initialised state. Every command is now guarded with `bashio::exit.nok` and a message naming what failed, matching the style already used elsewhere in this add-on.

**Symlinks are now idempotent.** Three of the four used bare `ln -s`, so a re-run failed, and because `ln -s` dereferences an existing symlinked directory it created a nested link inside the target rather than erroring cleanly. Running the merged script twice demonstrates both problems at once:

```
first run  exit=0
ln: /var/lib/nginx/tmp/nginx: File exists
second run exit=0            <- failure swallowed

stray symlinks left behind:
  /tmp/nginx/nginx
```

All four now use `ln -sfn`, which replaces an existing link and refuses to descend into a directory. After the change, running it twice leaves no stray paths and both runs exit 0.

In normal operation s6-rc runs a oneshot once per container start, so this was latent rather than an active bug. The error handling is the part that matters day to day.

**`chmod 777` becomes `chmod 644`** on `/var/lib/nginx/logs/error.log`. Nginx runs as root in this add-on, so world-writable was never needed. Nginx opens this path before it has parsed its configuration, which is why the file has to exist at all.

**Empty DNS host is now caught.** `init-nginx/run` substituted `bashio::dns.host` into `resolvers.conf` without checking it. An empty value produced `resolver ;`, and Nginx then failed with a syntax error that gives no hint about the real cause. It now fails with a clear message instead.

**Cosmetic.** `/tmp/nginx/cache/private\` was missing the space before its line continuation. It happened to work, because the backslash-newline joins the lines and the next line's indentation separates the arguments, but it is fragile.

## Verification

Built with `--no-cache` and exercised in the container, running `init-npm/run` verbatim from the image:

- Both runs exit 0, and the second leaves no stray nested symlinks. All four links point where they should.
- `error.log` is `-rw-r--r--` and `nginx -t` still reports the configuration valid, confirming 644 is sufficient.
- Admin UI returns HTTP 200, `/api/` returns `{"status":"OK","setup":false,...}`, zero backend errors or warnings.
- Confirmed `bashio::var.has_value` exists in the base image and returns false for an empty string, so the new guard fires as intended.
- Shellcheck, Prettier and YAMLLint all clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Part of the repository review follow-up, after #745.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup validation and error reporting when Home Assistant DNS configuration cannot be determined.
  * Added safeguards for Nginx resolver setup and add-on initialization failures.
  * Improved handling of setup links and directory creation during startup.
  * Tightened permissions on the Nginx error log for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->