### PR TITLE
Harden and quiet the image build

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -34,12 +34,12 @@ RUN \
         python3=3.14.7-r1 \
         yarn=1.22.22-r1 \
     \
-    && yarn global add modclean \
+    && yarn global add modclean@3.0.0-beta.1 \
     \
-    && curl -J -L -o /tmp/nginxproxymanager.tar.gz \
+    && curl -fsSL -o /tmp/nginxproxymanager.tar.gz \
         "https://github.com/NginxProxyManager/nginx-proxy-manager/archive/${NGINX_PROXY_MANAGER_VERSION}.tar.gz" \
     && mkdir /app \
-    && tar zxvf \
+    && tar zxf \
         /tmp/nginxproxymanager.tar.gz \
         --strip 1 -C /app \
     \
@@ -48,7 +48,7 @@ RUN \
         || exit 1; done \
     \
     && cd /app/frontend \
-    && yarn install --network-timeout 100000 \
+    && yarn install --frozen-lockfile --network-timeout 100000 \
     && yarn locale-compile \
     && yarn build \
     && rm -rf node_modules \
@@ -56,13 +56,10 @@ RUN \
     && mkdir -p /opt/nginx-proxy-manager/frontend \
     && cp -r /app/frontend/dist/. /opt/nginx-proxy-manager/frontend/ \
     \
-    && cd /app/backend \
-    && yarn install \
-    && rm -rf node_modules \
     && cp -r /app/backend/. /opt/nginx-proxy-manager/ \
     \
     && cd /opt/nginx-proxy-manager \
-    && yarn install \
+    && yarn install --frozen-lockfile \
     && rm -rf /opt/nginx-proxy-manager/config \
     \
     && rm -f -r /etc/nginx \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Build reliability and reproducibility changes. The resulting image is unchanged in behaviour.

**Fail fast on a bad download.** `curl` had no `--fail`, so an HTTP error was written to disk as if it were the tarball and the build continued until `tar` choked on it. Demonstrated in the image:

```
old:  curl -J -L -o ...   exit=0   file=14 bytes  contents: "404: Not Found"
new:  curl -fsSL -o ...   exit=22  file=0 bytes
```

The old form buried the real cause one step downstream. `-J` was also a no-op alongside `-o`, and `-sS` drops the progress meter while keeping errors.

**Quiet `tar`.** `zxvf` printed every extracted path. Dropping `v` takes the build log from **1355 lines to 311**. This is not cosmetic: the file list buried the actual error twice while debugging the v2.15.1 upgrade.

**Remove a discarded dependency install.** The backend `yarn install` was immediately undone by `rm -rf node_modules` on the next line, before the real install at `/opt`. The backend `package.json` has no `postinstall` or `prepare` hook that would give it a side effect. Its only real effect was warming the yarn cache, so the saving is modest rather than the full duration of the step: total build time goes from 108.1s to 103.3s.

**Reproducible installs.** Both `yarn install` calls now use `--frozen-lockfile`, so a lockfile that does not match `package.json` fails the build instead of silently resolving something else. Verified this passes against upstream's shipped lockfiles.

**Pin `modclean`.** It was installed unpinned, so the tool deciding what gets stripped from `node_modules` could change under us. Pinned to `3.0.0-beta.1`, which is what the build already resolved to and is currently the only published version. Note this pin is not covered by the Renovate custom manager, which only tracks the `apk` pins, so it will need updating by hand.

## Verification

Built with `--no-cache` and smoke tested:

- Build succeeds, no lockfile complaints from either install. The one "Regenerating lockfile" line in the log comes from `yarn global remove modclean`, not from our installs.
- `modclean@3.0.0-beta.1` confirmed installed by the log.
- Backend dependencies are intact after removing the discarded install: 319 entries in `node_modules` and `require("express")` loads.
- `nginx -t` valid, admin UI returns HTTP 200, `/api/` returns `{"status":"OK","setup":false,...}`, zero backend errors under the production `--abort_on_uncaught_exception` flag.
- Hadolint clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Part of the repository review follow-up, after #746.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
