### PR TITLE
Drop modclean from the image build

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -34,8 +34,6 @@ RUN \
         python3=3.14.7-r1 \
         yarn=1.22.22-r1 \
     \
-    && yarn global add modclean@3.0.0-beta.1 \
-    \
     && curl -fsSL -o /tmp/nginxproxymanager.tar.gz \
         "https://github.com/NginxProxyManager/nginx-proxy-manager/archive/${NGINX_PROXY_MANAGER_VERSION}.tar.gz" \
     && mkdir /app \
@@ -80,13 +78,6 @@ RUN \
     && mkdir -p \
         /run/nginx \
     \
-    && modclean \
-        --path /opt/nginx-proxy-manager \
-        --no-progress \
-        --keep-empty \
-        --run \
-    \
-    && yarn global remove modclean \
     && yarn cache clean \
     \
     && apk del --purge .build-dependencies \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Removes `modclean` from the build. It strips files from `node_modules` to shrink the image, and the trade is no longer worth it.

**It is effectively unmaintained.** The newest published version is `3.0.0-beta.1` from **May 2018**, a prerelease that was never promoted to stable and is the only version npm currently offers. The last commit to the repository was **December 2017**, and it has 22 open issues. #747 pinned it precisely because an unpinned dependency in that position is risky; removing it is the better answer to the same problem.

**What it was buying.** Measured by building the image both ways:

| | with | without |
| --- | --- | --- |
| Image | 335.9 MB | 345.9 MB |
| `node_modules` | 176.5 MB / 6455 files | 191.6 MB / 8291 files |
| Build time | 103.3s | 91.4s |

So 10.0 MB, or 2.9% of an image that is already ~346 MB. Removing it also makes the build about 12 seconds faster, since installing, running and then uninstalling the tool costs more than the deletion itself saves.

**It was not misbehaving.** Worth stating plainly, since that is not the reason for removing it. Of the 1836 files it deleted, 570 were `.md`, 563 were sourcemaps and 228 were JavaScript, and of those JavaScript files 229 of 234 sat under `test/`, `example/`, `bench/` or `fixture/` paths. The remaining five were `.eslintrc.js` files and two `example.js`. No runtime code was touched.

The concern is structural rather than behavioural: an unmaintained tool bulk-deleting roughly 1800 files from `node_modules` by pattern is a poor bargain for 2.9%, and if a future dependency ever ships something runtime-relevant under a `test/`-shaped path, the resulting failure would appear at runtime and be hard to trace back to a build-time deletion.

If the 10 MB is ever wanted back, most of it is sourcemaps and markdown, which an explicit `find` in this repository would recover without a third-party dependency.

## Verification

Built with `--no-cache` and smoke tested:

- Build succeeds with zero `modclean` references remaining in the log.
- `node_modules` is intact at 8291 files.
- `nginx -t` valid, admin UI returns HTTP 200, `/api/` returns `{"status":"OK","setup":false,...}`, zero backend errors under the production `--abort_on_uncaught_exception` flag.
- A certbot DNS plugin install still succeeds, which exercises the Python path that the stripped tree could plausibly have affected.
- Hadolint clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows #747, which pinned this dependency.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
