### PR TITLE
Reconcile the certbot log directory and cap log retention

### DIFF
--- a/proxy-manager/rootfs/etc/letsencrypt.ini
+++ b/proxy-manager/rootfs/etc/letsencrypt.ini
@@ -5,4 +5,5 @@ key-type = ecdsa
 elliptic-curve = secp384r1
 preferred-chain = ISRG Root X1
 work-dir = /tmp/letsencrypt-lib
-logs-dir = /tmp/letsencrypt-log
+logs-dir = /config/logs
+max-log-backups = 10

--- a/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-npm/run
+++ b/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/init-npm/run
@@ -18,7 +18,6 @@ mkdir -p \
     /config/nginx/stream \
     /config/nginx/temp \
     /tmp/letsencrypt-lib \
-    /tmp/letsencrypt-log \
     /tmp/nginx/body \
     /tmp/nginx/cache/private \
     /tmp/nginx/cache/public \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Makes `letsencrypt.ini` agree with where certbot logs actually go, and bounds their growth.

**The configured path was dead.** `letsencrypt.ini` declared `logs-dir = /tmp/letsencrypt-log`, but the backend passes `--logs-dir` on the command line for every certbot invocation, and a command line flag overrides the configuration file. Demonstrated in the image:

```
A) ini alone                      -> /tmp/letsencrypt-log: 2   /config/logs: 0
B) ini + the flag the backend passes -> /tmp/letsencrypt-log: 2   /config/logs: 2
```

Since the backend always passes the flag, real installs only ever wrote to `/config/logs`. The ini's setting applied to nothing, and `/tmp/letsencrypt-log` was created by `init-npm/run` for nothing. The ini now says `/config/logs` and that `mkdir` is gone, so the two agree and shelling in to run certbot by hand lands in the same place the add-on uses.

This divergence appeared with #743. Before v2.15.1 upstream hardcoded `/tmp/letsencrypt-log` in the certbot arguments, matching the ini; v2.15.1 introduced `certbotLogsDir` pointing at `/data/logs`, which the `/data` to `/config` patch maps to `/config/logs`.

**Certbot logs are now persistent, so retention is capped.** That is a side effect of the same upstream change: these logs used to live in `/tmp` and vanish on restart, and they now sit in the user's config share. Certbot's default `max-log-backups` is **1000**, so up to 1001 files could accumulate there over time. The ini now sets `max-log-backups = 10`, which keeps enough history to debug a failed renewal without letting the directory grow indefinitely. They remain excluded from backups by the existing `backup_exclude: "*/logs"`.

## Verification

Built with `--no-cache` and exercised in the container:

- Running certbot with the ini alone now writes to `/config/logs`, the same directory the backend uses, so the two no longer disagree.
- Retention is enforced: after 17 certbot runs the directory holds exactly 11 files, the current log plus 10 backups. Without the cap that would have been 17 and climbing toward 1001.
- `grep` finds no remaining reference to `/tmp/letsencrypt-log` anywhere in the repository.
- `nginx -t` valid, admin UI returns HTTP 200, `/api/` returns `{"status":"OK","setup":false,...}`, zero backend errors.
- Shellcheck and YAMLLint clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Cleans up a divergence introduced by #743.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Let’s Encrypt logging to use the application’s persistent configuration logs directory.
  * Limited retained Let’s Encrypt log backups to 10.
  * Removed setup for the obsolete temporary log directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->