### PR TITLE
Document ports, storage and troubleshooting; add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Local tooling and editor state
+.claude/
+
+# OS noise
+.DS_Store
+Thumbs.db

--- a/proxy-manager/DOCS.md
+++ b/proxy-manager/DOCS.md
@@ -35,7 +35,51 @@ comparison to installing any other Home Assistant app.
 
 ## Configuration
 
-This app does not provide any configuration.
+This app does not provide any configuration options.
+
+## Ports
+
+This app binds three ports on your Home Assistant machine:
+
+| Port  | Purpose                                                       |
+| ----- | ------------------------------------------------------------- |
+| `80`  | HTTP entrance, also used by Let's Encrypt to validate domains |
+| `81`  | The admin web interface                                       |
+| `443` | HTTPS entrance                                                |
+
+Ports `80` and `443` need to be free on your machine. If Home Assistant
+itself is serving SSL on port `443`, or another app already uses one of
+these ports, this app will not start. The host side of each port can be
+changed in the app's "Network" configuration.
+
+## Storage
+
+Everything this app stores lives in its own configuration folder, which
+you can reach at `/addon_configs/a0d7b954_nginxproxymanager` with the
+"File editor" or "Samba" apps:
+
+| Item              | Contents                                     |
+| ----------------- | -------------------------------------------- |
+| `database.sqlite` | Your hosts, users, certificates and settings |
+| `access`          | Username and password files for access lists |
+| `custom_ssl`      | Certificates you uploaded yourself           |
+| `letsencrypt`     | Certificates issued by Let's Encrypt         |
+| `logs`            | Certbot logs, excluded from backups          |
+| `nginx`           | The generated Nginx configuration            |
+| `nginx/custom`    | Your own additional Nginx directives         |
+
+Files placed in `nginx/custom` are included by the generated configuration,
+which is how the advanced options in the web interface are applied.
+
+## Troubleshooting
+
+Start with the app's own log, which carries both the Nginx and the Nginx
+Proxy Manager output.
+
+If a certificate fails to issue or renew, certbot writes its own, more
+detailed log to `logs/letsencrypt.log` in the folder above. The most common
+causes are port `80` not being reachable from the internet, or DNS for the
+domain not pointing at your connection.
 
 ## Changelog & Releases
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Fills three gaps in the documentation and adds a repository `.gitignore`.

**Ports.** The docs never mentioned that this app binds `80`, `81` and `443` on the host, or that it will not start if something else already holds them. Home Assistant serving its own SSL on `443` is the obvious collision. Now documented, along with the fact that the host side of each port can be changed in the app's Network configuration.

**Storage.** Nothing said where the data lives. Users had no documented way to find their database, certificates or the custom Nginx directives folder. The new section names the host path, `/addon_configs/a0d7b954_nginxproxymanager`, and tables what each item under it holds. The contents were taken from a real first run rather than written from memory.

It also documents `nginx/custom`, which is worth calling out: the generated configuration includes files from there, and that is the mechanism behind the advanced options in the web interface.

**Troubleshooting.** A short section pointing at the app log first, then at `logs/letsencrypt.log` for certificate problems, with the two usual causes. Certbot's log only became reachable to users when it moved into the config folder, so this is newly worth documenting.

**`.gitignore`.** The repository had none. `.claude/` was only being excluded by the maintainer's global gitignore, so a contributor with different global settings would commit their local tooling state. Now ignored by the repository itself, along with the usual OS noise.

Also reworded "This app does not provide any configuration" to "does not provide any configuration options", since the app plainly does have configuration, just not add-on options.

## Verification

- `.claude/settings.local.json` is now matched by the repository's own `.gitignore` rather than a global one, confirmed with `git check-ignore -v`.
- The storage table was checked against a real container after a first run, so the listed folders and `database.sqlite` are what actually appears.
- Prettier and YAMLLint clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Final item of the repository review follow-up, after #749.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
