### PR TITLE
Report the actual Nginx Proxy Manager version in the web UI

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -56,6 +56,11 @@ RUN \
     \
     && cp -r /app/backend/. /opt/nginx-proxy-manager/ \
     \
+    && sed -i "s#\"version\": \"[^\"]*\"#\"version\": \"${NGINX_PROXY_MANAGER_VERSION#v}\"#" \
+        /opt/nginx-proxy-manager/package.json \
+    && grep -q "\"version\": \"${NGINX_PROXY_MANAGER_VERSION#v}\"" \
+        /opt/nginx-proxy-manager/package.json \
+    \
     && cd /opt/nginx-proxy-manager \
     && yarn install --frozen-lockfile \
     && rm -rf /opt/nginx-proxy-manager/config \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The web UI reported version 2.0.0 regardless of which Nginx Proxy Manager release the image actually contains.

Upstream ships `backend/package.json` with a placeholder version of `2.0.0` and substitutes the real one in their own release pipeline. This app builds straight from the source tarball, so that substitution never happened and the placeholder shipped as is. Both the footer and the login page read their version from `GET /api`, which returns exactly that field, so both showed 2.0.0.

The build now writes `NGINX_PROXY_MANAGER_VERSION` into that field. The `grep` guard right after it is the part that matters for the long run: this bug was silent, so if upstream ever renames or restructures the field, the build should fail rather than quietly ship the placeholder again.

Verified on a local build of the image:

```
$ grep -m1 '"version"' /opt/nginx-proxy-manager/package.json
        "version": "2.15.1",
UI will show: v2.15.1
```

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Fixes #752

Also explains the "seems to actually install version 2.0.0" observation in #725, which is the same display bug rather than a failed update.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build validation to ensure the packaged proxy manager version is correctly recorded.
  * Builds now fail clearly when the expected version information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->