### PR TITLE
Keep certbot DNS plugin installs from breaking certbot

### DIFF
--- a/proxy-manager/DOCS.md
+++ b/proxy-manager/DOCS.md
@@ -81,6 +81,12 @@ detailed log to `logs/letsencrypt.log` in the folder above. The most common
 causes are port `80` not being reachable from the internet, or DNS for the
 domain not pointing at your connection.
 
+A few Certbot DNS plugins still require an older Certbot than the one this app
+ships. Installing them is refused rather than allowed to replace Certbot, and
+the app log names the plugin and the conflict. Those providers stay unavailable
+until the plugin catches up upstream; certificates using another challenge type
+are not affected.
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]

--- a/proxy-manager/DOCS.md
+++ b/proxy-manager/DOCS.md
@@ -81,11 +81,11 @@ detailed log to `logs/letsencrypt.log` in the folder above. The most common
 causes are port `80` not being reachable from the internet, or DNS for the
 domain not pointing at your connection.
 
-A few Certbot DNS plugins still require an older Certbot than the one this app
-ships. Installing them is refused rather than allowed to replace Certbot, and
-the app log names the plugin and the conflict. Those providers stay unavailable
-until the plugin catches up upstream; certificates using another challenge type
-are not affected.
+A few Certbot DNS plugins still require an older Certbot, or an older version of
+one of the libraries it builds on, than this app ships. Installing them is
+refused rather than allowed to replace Certbot, and the app log names the plugin
+and the conflict. Those providers stay unavailable until the plugin catches up
+upstream; certificates using another challenge type are not affected.
 
 ## Changelog & Releases
 

--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -34,6 +34,11 @@ RUN \
         python3=3.14.7-r1 \
         yarn=1.22.22-r1 \
     \
+    && python3 -c "from importlib.metadata import version; \
+        print('\n'.join(f'{p}=={version(p)}' \
+        for p in ('acme', 'certbot', 'josepy')))" \
+        > /etc/certbot-constraints.txt \
+    \
     && curl -fsSL -o /tmp/nginxproxymanager.tar.gz \
         "https://github.com/NginxProxyManager/nginx-proxy-manager/archive/${NGINX_PROXY_MANAGER_VERSION}.tar.gz" \
     && mkdir /app \
@@ -97,6 +102,9 @@ RUN \
         /var/log/nginx \
         /var/tmp/nginx \
         /var/www
+
+# Keep pip from replacing the Certbot stack that ships with the image
+ENV PIP_CONSTRAINT=/etc/certbot-constraints.txt
 
 # Copy root filesystem
 COPY rootfs /

--- a/proxy-manager/patches/0001-patch-data-to-config-and-logs-to-stdout.patch
+++ b/proxy-manager/patches/0001-patch-data-to-config-and-logs-to-stdout.patch
@@ -1,7 +1,7 @@
 From c4291d697d799149e8c57a933fd0a1c431e8e4d7 Mon Sep 17 00:00:00 2001
 From: Franck Nijhof <opensource@frenck.dev>
 Date: Fri, 21 Aug 2026 15:04:59 +0200
-Subject: [PATCH 1/3] Patch /data to /config folder
+Subject: [PATCH 1/4] Patch /data to /config folder
 
 The add-on stores its user-visible state in /config (the addon_config
 share) instead of the upstream /data location.

--- a/proxy-manager/patches/0002-Patch-redirect-logs-to-docker-output.patch
+++ b/proxy-manager/patches/0002-Patch-redirect-logs-to-docker-output.patch
@@ -1,7 +1,7 @@
 From d2da98aeecf4c1a21207c161d3529ef5a8821a8e Mon Sep 17 00:00:00 2001
 From: Franck Nijhof <opensource@frenck.dev>
 Date: Fri, 21 Aug 2026 15:05:00 +0200
-Subject: [PATCH 2/3] Patch redirect logs to docker output
+Subject: [PATCH 2/4] Patch redirect logs to docker output
 
 Sends the NGINX access and error logs to the container's stdout so they
 show up in the add-on log, instead of writing them to files the user

--- a/proxy-manager/patches/0003-Patch-npm-certbot-venv-plugin-handling.patch
+++ b/proxy-manager/patches/0003-Patch-npm-certbot-venv-plugin-handling.patch
@@ -1,7 +1,7 @@
 From c2cf11aff40767696c1ea808c89d311bc0db46d5 Mon Sep 17 00:00:00 2001
 From: Franck Nijhof <opensource@frenck.dev>
 Date: Fri, 21 Aug 2026 15:05:01 +0200
-Subject: [PATCH 3/3] Patch npm certbot venv plugin handling
+Subject: [PATCH 3/4] Patch npm certbot venv plugin handling
 
 Upstream installs DNS plugins into a Python virtualenv at /opt/certbot.
 This add-on installs certbot from Alpine's package repository instead,

--- a/proxy-manager/patches/0004-Patch-certbot-plugin-install-failures-at-startup.patch
+++ b/proxy-manager/patches/0004-Patch-certbot-plugin-install-failures-at-startup.patch
@@ -1,0 +1,50 @@
+From 60a2c46a72bdf59be507ac373271e369b1f27814 Mon Sep 17 00:00:00 2001
+From: Franck Nijhof <opensource@frenck.dev>
+Date: Mon, 24 Aug 2026 12:00:00 +0200
+Subject: [PATCH 4/4] Patch certbot plugin install failures at startup
+
+Upstream retries its whole startup chain every second when any step
+rejects, and a Certbot DNS plugin that cannot be installed rejects on
+every pass. With pip's cache disabled that re-downloads the plugin and
+all of its dependencies on each attempt, tens of gigabytes per hour,
+while the add-on gives no sign that anything is wrong.
+
+Logs the failure once per start and lets the rest of the app come up.
+Certificate operations for that provider still fail, visibly, when they
+are used.
+---
+ backend/setup.js | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/backend/setup.js b/backend/setup.js
+index 84f4279..9565ce8 100644
+--- a/backend/setup.js
++++ b/backend/setup.js
+@@ -132,11 +132,22 @@ const setupCertbotPlugins = async () => {
+ 			return true;
+ 		});
+ 
+-		await installPlugins(plugins);
++		let installed = true;
++		try {
++			await installPlugins(plugins);
++		} catch (err) {
++			// Rejecting here aborts startup, which upstream retries every second.
++			// One plugin that cannot be installed then becomes an endless install
++			// loop that re-downloads every dependency on each attempt.
++			installed = false;
++			logger.error(`Certbot plugins ${plugins.join(", ")} are unavailable: ${err.message}`);
++		}
+ 
+ 		if (promises.length) {
+ 			await Promise.all(promises);
+-			logger.info(`Added Certbot plugins ${plugins.join(", ")}`);
++			if (installed) {
++				logger.info(`Added Certbot plugins ${plugins.join(", ")}`);
++			}
+ 		}
+ 	}
+ };
+-- 
+2.39.5
+

--- a/proxy-manager/patches/0004-Patch-certbot-plugin-install-failures-at-startup.patch
+++ b/proxy-manager/patches/0004-Patch-certbot-plugin-install-failures-at-startup.patch
@@ -1,4 +1,4 @@
-From 60a2c46a72bdf59be507ac373271e369b1f27814 Mon Sep 17 00:00:00 2001
+From 5a9304111afd1b5792eceedb7fdf546d5e1071c7 Mon Sep 17 00:00:00 2001
 From: Franck Nijhof <opensource@frenck.dev>
 Date: Mon, 24 Aug 2026 12:00:00 +0200
 Subject: [PATCH 4/4] Patch certbot plugin install failures at startup
@@ -17,7 +17,7 @@ are used.
  1 file changed, 13 insertions(+), 2 deletions(-)
 
 diff --git a/backend/setup.js b/backend/setup.js
-index 84f4279..9565ce8 100644
+index 84f4279..5dee5b3 100644
 --- a/backend/setup.js
 +++ b/backend/setup.js
 @@ -132,11 +132,22 @@ const setupCertbotPlugins = async () => {
@@ -33,7 +33,7 @@ index 84f4279..9565ce8 100644
 +			// One plugin that cannot be installed then becomes an endless install
 +			// loop that re-downloads every dependency on each attempt.
 +			installed = false;
-+			logger.error(`Certbot plugins ${plugins.join(", ")} are unavailable: ${err.message}`);
++			logger.error(`Certbot plugin installation failed, continuing anyway: ${err.message}`);
 +		}
  
  		if (promises.length) {


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Two problems in the Certbot DNS plugin install path. They share a root cause and have to be fixed together.

### Installing a plugin could break Certbot entirely

Because we install Certbot from Alpine instead of upstream's virtualenv, patch 0003 installs DNS plugins into the system site-packages. Five of the 86 plugins in upstream's list pin an older Certbot than the image ships, and pip will happily downgrade to satisfy them:

```
$ pip install --no-cache-dir 'azure-mgmt-dns==8.2.0' 'certbot-dns-azure~=2.6.1'
  Attempting uninstall: josepy
  Attempting uninstall: acme
  Attempting uninstall: certbot
Successfully installed ... acme-3.3.0 certbot-3.3.0 ... josepy-1.15.0
```

`acme` 2.11 through 3.x cap `josepy<2`, and josepy below 2.1 has no PEP 649 handling, so on the image's Python 3.14 every Certbot invocation then dies before it reaches the network:

```
$ certbot --version
ValueError: Field `alg` in JSONObject `Header` has no type annotation.
```

From that moment on, issuance and renewal are broken for every certificate, not just the one using that provider, and nothing in the UI says so.

The build now writes the shipped `acme`, `certbot` and `josepy` versions into a pip constraints file and points `PIP_CONSTRAINT` at it. Generating it from the installed packages keeps it correct across Renovate bumps. An incompatible plugin is now refused instead of being allowed to replace Certbot:

```
The conflict is caused by:
    certbot-dns-azure 2.6.1 depends on certbot<4.0 and >=3.0
    The user requested (constraint) certbot==5.6.0
ERROR: ResolutionImpossible
$ certbot --version
certbot 5.6.0
```

### A failed install retried forever

Upstream restarts its entire startup chain one second after any step rejects, and plugin installation runs on every pass. With pip's cache disabled (`PIP_NO_CACHE_DIR=1` from the base image) that re-downloads the plugin and all of its dependencies each time, reported at roughly 24GB per hour against `files.pythonhosted.org` and `wheels.home-assistant.io`, with no visible sign that anything is wrong. Patch 0004 logs the failure once per start and lets the rest of the app come up. Certificate operations for that provider still fail, visibly, when they are used.

That second half is why this is one change rather than two: constraining pip converts those five plugins from silent corruption into install failures, and without patch 0004 each of those failures would turn into the loop above.

### On the fix proposed in #754

`--only-binary=:all:` would stop the downloads, but nine of the 86 plugins publish sdists only. They are pure Python and install fine without a compiler, so the flag would take working providers away. All 86 were checked against PyPI.

### Affected plugins

`azure`, `constellix`, `oci`, `timeweb` and `websupport`. `timeweb` and `websupport` already have releases that support Certbot 5 and only need a pin bump in upstream's `dns-plugins.json`; the other three have no compatible release yet. Worth raising upstream separately.

Verified on a local build of the image: `certbot-dns-cloudflare` and the sdist only `certbot-dns-acmedns` still install and are picked up by `certbot plugins`, while `certbot-dns-azure` is refused and Certbot stays on 5.6.0.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Fixes #753
Fixes #754

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer troubleshooting guidance for incompatible Certbot DNS plugins.
  * The app now reports plugin installation conflicts while allowing startup to continue.
  * NGINX logs are available through the container’s standard output.

* **Bug Fixes**
  * Prevented plugin installation from replacing bundled Certbot dependencies.
  * Preserved existing JWT keys during upgrades.
  * Improved compatibility with modular NGINX stream support.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->