### PR TITLE
Bump the Timeweb and Websupport DNS plugin pins

### DIFF
--- a/proxy-manager/patches/0001-patch-data-to-config-and-logs-to-stdout.patch
+++ b/proxy-manager/patches/0001-patch-data-to-config-and-logs-to-stdout.patch
@@ -1,7 +1,7 @@
 From c4291d697d799149e8c57a933fd0a1c431e8e4d7 Mon Sep 17 00:00:00 2001
 From: Franck Nijhof <opensource@frenck.dev>
 Date: Fri, 21 Aug 2026 15:04:59 +0200
-Subject: [PATCH 1/4] Patch /data to /config folder
+Subject: [PATCH 1/5] Patch /data to /config folder
 
 The add-on stores its user-visible state in /config (the addon_config
 share) instead of the upstream /data location.

--- a/proxy-manager/patches/0002-Patch-redirect-logs-to-docker-output.patch
+++ b/proxy-manager/patches/0002-Patch-redirect-logs-to-docker-output.patch
@@ -1,7 +1,7 @@
 From d2da98aeecf4c1a21207c161d3529ef5a8821a8e Mon Sep 17 00:00:00 2001
 From: Franck Nijhof <opensource@frenck.dev>
 Date: Fri, 21 Aug 2026 15:05:00 +0200
-Subject: [PATCH 2/4] Patch redirect logs to docker output
+Subject: [PATCH 2/5] Patch redirect logs to docker output
 
 Sends the NGINX access and error logs to the container's stdout so they
 show up in the add-on log, instead of writing them to files the user

--- a/proxy-manager/patches/0003-Patch-npm-certbot-venv-plugin-handling.patch
+++ b/proxy-manager/patches/0003-Patch-npm-certbot-venv-plugin-handling.patch
@@ -1,7 +1,7 @@
 From c2cf11aff40767696c1ea808c89d311bc0db46d5 Mon Sep 17 00:00:00 2001
 From: Franck Nijhof <opensource@frenck.dev>
 Date: Fri, 21 Aug 2026 15:05:01 +0200
-Subject: [PATCH 3/4] Patch npm certbot venv plugin handling
+Subject: [PATCH 3/5] Patch npm certbot venv plugin handling
 
 Upstream installs DNS plugins into a Python virtualenv at /opt/certbot.
 This add-on installs certbot from Alpine's package repository instead,

--- a/proxy-manager/patches/0004-Patch-certbot-plugin-install-failures-at-startup.patch
+++ b/proxy-manager/patches/0004-Patch-certbot-plugin-install-failures-at-startup.patch
@@ -1,7 +1,7 @@
 From 5a9304111afd1b5792eceedb7fdf546d5e1071c7 Mon Sep 17 00:00:00 2001
 From: Franck Nijhof <opensource@frenck.dev>
 Date: Mon, 24 Aug 2026 12:00:00 +0200
-Subject: [PATCH 4/4] Patch certbot plugin install failures at startup
+Subject: [PATCH 4/5] Patch certbot plugin install failures at startup
 
 Upstream retries its whole startup chain every second when any step
 rejects, and a Certbot DNS plugin that cannot be installed rejects on

--- a/proxy-manager/patches/0005-Patch-bump-two-DNS-plugin-pins-that-block-certbot-5.patch
+++ b/proxy-manager/patches/0005-Patch-bump-two-DNS-plugin-pins-that-block-certbot-5.patch
@@ -1,0 +1,50 @@
+From 34caf596df4dc9cb28eeae6695c561e45dffd75c Mon Sep 17 00:00:00 2001
+From: Franck Nijhof <opensource@frenck.dev>
+Date: Tue, 25 Aug 2026 12:00:00 +0200
+Subject: [PATCH 5/5] Patch bump two DNS plugin pins that block certbot 5
+
+Upstream pins certbot-dns-timeweb to ~=1.0.1 and certbot-dns-websupport
+to ~=2.0.1. Both of those releases cap certbot below 3, so neither can
+be installed against the certbot this app ships and both providers are
+unusable.
+
+Newer releases lift the cap and are drop-in: same entry point, same
+credentials keys, so existing credential files keep working.
+
+  certbot-dns-timeweb    2.0.0  requires certbot>=2.8
+  certbot-dns-websupport 5.0.0  requires certbot<6,>=3.2.0
+
+Temporary. Once either bump lands upstream this patch stops applying and
+the build fails, which is the signal to drop the entry here.
+
+  https://github.com/NginxProxyManager/nginx-proxy-manager/pull/5800
+  https://github.com/NginxProxyManager/nginx-proxy-manager/pull/5788
+---
+ backend/certbot/dns-plugins.json | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/backend/certbot/dns-plugins.json b/backend/certbot/dns-plugins.json
+index 2208194..f066336 100644
+--- a/backend/certbot/dns-plugins.json
++++ b/backend/certbot/dns-plugins.json
+@@ -637,7 +637,7 @@
+ 		"full_plugin_name": "dns-timeweb",
+ 		"name": "Timeweb Cloud",
+ 		"package_name": "certbot-dns-timeweb",
+-		"version": "~=1.0.1"
++		"version": "~=2.0.0"
+ 	},
+ 	"transip": {
+ 		"credentials": "dns_transip_username = my_username\ndns_transip_key_file = /etc/letsencrypt/transip-rsa.key",
+@@ -661,7 +661,7 @@
+ 		"full_plugin_name": "dns-websupport",
+ 		"name": "Websupport.sk",
+ 		"package_name": "certbot-dns-websupport",
+-		"version": "~=2.0.1"
++		"version": "~=5.0.0"
+ 	},
+ 	"wedos": {
+ 		"credentials": "dns_wedos_user = <wedos_registration>\ndns_wedos_auth = <wapi_password>",
+-- 
+2.39.5
+


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Upstream pins `certbot-dns-timeweb` to `~=1.0.1` and `certbot-dns-websupport` to `~=2.0.1`. Both of those releases cap Certbot below 3, so neither can be installed against the Certbot this app ships, and both providers are unusable. Newer releases lift the cap:

| plugin | pin | to | requires |
| --- | --- | --- | --- |
| `certbot-dns-timeweb` | `~=1.0.1` | `~=2.0.0` | `certbot>=2.8` |
| `certbot-dns-websupport` | `~=2.0.1` | `~=5.0.0` | `certbot<6,>=3.2.0` |

Both are drop-in. Same entry point (`dns-timeweb`, `dns-websupport`) and same credentials keys (`api_key`, and `identifier` / `secret_key`), so existing credential files keep working and no other field in the entry changes. Verified against our Certbot 5.6.0 with the constraints from #757 in place: both install, the Certbot stack stays on 5.6.0 / josepy 2.2.0, and both register in `certbot plugins`.

This is temporary. Once either bump lands upstream the hunk is already present, `patch --forward` exits 1, and the build fails, which is the signal to drop that entry here.

Scope: a dry-run install sweep of all 86 plugins against this image says only these two are fixable by a pin. `azure` and `oci` cap Certbot below 4 in their newest releases, and `dnsmulti` ships manylinux wheels only, so on musl pip falls back to an sdist that needs a Go toolchain. None of those three can be fixed by a version pin.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows up on #753.

Upstream equivalents, which supersede this patch once merged:

* https://github.com/NginxProxyManager/nginx-proxy-manager/pull/5800 (Timeweb)
* https://github.com/NginxProxyManager/nginx-proxy-manager/pull/5788 (Websupport)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
